### PR TITLE
Fast ECT computation with gradients. 

### DIFF
--- a/fastect.py
+++ b/fastect.py
@@ -1,0 +1,80 @@
+"""
+Fast ECT calculation for point cloud
+backprop with custom gradient.
+"""
+
+import matplotlib.pyplot as plt
+import torch
+
+
+class Sigmoid(torch.autograd.Function):
+    @staticmethod
+    def forward(x, _):
+        return torch.heaviside(x, values=torch.tensor(0.0))
+
+    @staticmethod
+    def setup_context(ctx, inputs, _):
+        (x, slope) = inputs
+        ctx.slope = slope
+        ctx.save_for_backward(x)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (input_,) = ctx.saved_tensors
+        grid_size = len(input_)
+        ind_leq = input_ <= 1 / (1.5 * grid_size)
+        ind_geq = input_ >= -1 / (1.5 * grid_size)
+        grad = (1 / ctx.slope) * (ind_leq & ind_geq) * grad_output
+        return grad, None
+
+
+def fastsigmoid(slope=0.01):
+    """Sigmoid surrogate gradient enclosed with a parameterized slope."""
+    slope = slope
+
+    def inner(x):
+        return Sigmoid.apply(x, slope)
+
+    return inner
+
+
+lin = torch.linspace(0, 1, 200)
+h = torch.nn.Parameter(data=torch.tensor(0.5))
+
+h_true = torch.tensor(0.75)
+sig = fastsigmoid()
+
+
+optimizer = torch.optim.Adam([h], lr=0.005)
+
+sig_true = sig(lin - h_true.unsqueeze(0))
+
+
+hs = []
+
+for epoch in range(400):
+    optimizer.zero_grad()
+    sig_pred = sig(lin - h.unsqueeze(0))
+
+    loss = torch.nn.functional.mse_loss(sig_true, sig_pred)
+
+    loss.backward()
+    optimizer.step()
+
+    hs.append(h.item())
+
+    print(
+        epoch,
+        "Loss:",
+        loss.item(),
+        "h",
+        h.item(),
+        # "Sig_true",
+        # sig_true.item(),
+        # "Sig Pred",
+        # sig_pred.item(),
+    )
+
+plt.plot(hs)
+plt.show()
+print(1 / 200)

--- a/fastectgrad.py
+++ b/fastectgrad.py
@@ -1,0 +1,85 @@
+"""
+Fast ECT calculation for point cloud
+backprop with custom gradient.
+"""
+
+import matplotlib.pyplot as plt
+import torch
+
+from dect.directions import generate_2d_directions
+
+
+def bincount(idx, resolution):
+    """Calculates the histogram in resolution bins."""
+    x = torch.zeros(size=(resolution, resolution), dtype=torch.float32, device="cuda")
+    return x.scatter_(0, idx.to(torch.int64), 1, reduce="add")
+
+
+def fast_ect_fn(x, v):
+    """Fast ECT for point clouds."""
+    resolution = v.shape[1]
+    nh = ((torch.matmul(x, v) + 1) * (resolution // 2)).to(torch.uint32)
+    return bincount(nh, resolution), nh
+
+
+# x = torch.rand(size=(5, 2)) * 0.5
+# ect = fast_ect_fn(x, v)
+# plt.imshow(ect.cumsum(dim=0).numpy())
+# plt.show()
+
+
+class FastECT(torch.autograd.Function):
+    @staticmethod
+    def forward(x, v):
+        ect, idx = fast_ect_fn(x, v)
+        return ect.cumsum(dim=0), ect, idx
+
+    @staticmethod
+    def setup_context(ctx, inputs, outputs):
+        (ect, ect_grad, idx) = outputs
+        (_, v) = inputs
+        ctx.save_for_backward(ect, ect_grad, idx, v)
+
+    @staticmethod
+    def backward(ctx, grad_output, _, __):
+        (ect, ect_grad, idx, v) = ctx.saved_tensors
+        grad = ect_grad * grad_output / v.shape[1]
+        # Do not know if this will be correct.
+        ect_final_grad = torch.gather(grad, dim=0, index=idx.to(torch.int64))
+        out = ect_final_grad @ v.T
+        return -1 * out, None
+
+
+def fastect(x, v):
+    ect, _, _ = FastECT.apply(x, v)
+    return ect
+
+
+v = generate_2d_directions(num_thetas=2048).cuda()
+x_true = 0.5 * torch.rand(size=(10000, 2)).cuda()
+x = torch.nn.Parameter(0.2 * (torch.rand(size=(10000, 2), device="cuda") - 0.5))
+
+
+optimizer = torch.optim.Adam([x], lr=0.01)
+
+
+for epoch in range(200):
+    optimizer.zero_grad()
+    ect_true = fastect(x_true, v)
+    ect_pred = fastect(x, v)
+    loss = torch.nn.functional.mse_loss(ect_pred, ect_true)
+    loss.backward()
+    optimizer.step()
+
+
+# plt.imshow(ect_true.detach().numpy())
+fig, axes = plt.subplots(nrows=2, ncols=2)
+axes[0, 0].imshow(ect_pred.detach().cpu().numpy())
+axes[0, 1].imshow(ect_true.detach().cpu().numpy())
+x_true = x_true.cpu().numpy()
+x = x.detach().cpu().numpy()
+axes[1, 0].scatter(x_true[:, 0], x_true[:, 1])
+axes[1, 0].scatter(x[:, 0], x[:, 1])
+axes[1, 0].set_xlim([-1, 1])
+axes[1, 0].set_ylim([-1, 1])
+plt.show()


### PR DESCRIPTION
Added the backwards pass for the FECT and tested the rendering of 10k points at an ECT resolution of 2k.

Some noteworthy notes: 
- Only implemented for nodes at the moment. 
- Not double checked for errors/bugs. Please contact me if you do find one or if you have suggestions on how to make it faster. 

